### PR TITLE
Deploy both primary auction house microservices to Tectonic Cluster

### DIFF
--- a/codebase/commons/src/main/resources/application.conf
+++ b/codebase/commons/src/main/resources/application.conf
@@ -1,1 +1,2 @@
 cassandra.contactPoint = "127.0.0.1"
+cassandra.contactPoint = ${?CASSANDRA_CONTACT_POINT}

--- a/codebase/commons/src/main/resources/application.conf
+++ b/codebase/commons/src/main/resources/application.conf
@@ -1,2 +1,1 @@
-cassandra.contactPoint = "127.0.0.1"
 cassandra.contactPoint = ${?CASSANDRA_CONTACT_POINT}

--- a/infra/manifests/auction-house-primary-async.dev.yaml
+++ b/infra/manifests/auction-house-primary-async.dev.yaml
@@ -1,0 +1,63 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: microservices
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: auction-house-primary-async
+  namespace: microservices
+spec:
+  selector:
+    app: auction-house-primary-async
+  ports:
+    - protocol: TCP
+      port: 443
+      targetPort: 8080
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: auction-house-primary-async
+  namespace: microservices
+  annotations:
+    kubernetes.io/ingress.class: "tectonic"
+    ingress.kubernetes.io/rewrite-target: /
+spec:
+  tls:
+  - hosts:
+      - auction-house-primary-async.local
+  rules:
+  - host: auction-house-primary-async.local
+    http:
+      paths:
+      - backend:
+          serviceName: auction-house-primary-async
+          servicePort: 443
+        path: /
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: auction-house-primary-async
+  namespace: microservices
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: auction-house-primary-async
+    spec:
+      containers:
+        - name: auction-house-primary-async
+          image: docker-registry.local/auction-house-primary-async
+          resources:
+            limits:
+              memory: "192Mi"
+          ports:
+            - containerPort: 8080
+          env:
+            - name: CASSANDRA_CONTACT_POINT
+              value: "cassandra-0.cassandra.databases.svc.cluster.local"

--- a/infra/manifests/auction-house-primary-sync.dev.yaml
+++ b/infra/manifests/auction-house-primary-sync.dev.yaml
@@ -1,0 +1,63 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: microservices
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: auction-house-primary-sync
+  namespace: microservices
+spec:
+  selector:
+    app: auction-house-primary-sync
+  ports:
+    - protocol: TCP
+      port: 443
+      targetPort: 8080
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: auction-house-primary-sync
+  namespace: microservices
+  annotations:
+    kubernetes.io/ingress.class: "tectonic"
+    ingress.kubernetes.io/rewrite-target: /
+spec:
+  tls:
+  - hosts:
+      - auction-house-primary-sync.local
+  rules:
+  - host: auction-house-primary-sync.local
+    http:
+      paths:
+      - backend:
+          serviceName: auction-house-primary-sync
+          servicePort: 443
+        path: /
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: auction-house-primary-sync
+  namespace: microservices
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: auction-house-primary-sync
+    spec:
+      containers:
+        - name: auction-house-primary-sync
+          image: docker-registry.local/auction-house-primary-sync
+          resources:
+            limits:
+              memory: "192Mi"
+          ports:
+            - containerPort: 8080
+          env:
+            - name: CASSANDRA_CONTACT_POINT
+              value: "cassandra-0.cassandra.databases.svc.cluster.local"

--- a/tectonic-1.7.5/Vagrantfile
+++ b/tectonic-1.7.5/Vagrantfile
@@ -26,7 +26,7 @@ end
 
 $update_channel = "alpha"
 $controller_vm_memory = 1280
-$worker_vm_memory = 3072
+$worker_vm_memory = 4096
 
 if $worker_vm_memory < 1536
   puts "Workers need at least 1536 MB of memory"


### PR DESCRIPTION
Needed to bump cluster memory on worker node due to:
- 2 cassandras taking 512MB each
- 2 auction-house-primary services taking 192MB each