### PR TITLE
Handling AWS credentials for S3 in containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,17 @@
  * kubectl (https://kubernetes.io/docs/tasks/tools/install-kubectl/ )
  * Vagrant ( tested on ver. 2.0.x, https://www.vagrantup.com/downloads.html )
 
+### Prerequistes
+
+Make sure to export following environment variables on your host:
+
+* Key and secret for user: `billing-service-worker`
+
+```bash
+export BILLING_WORKER_AWS_KEY=xxxxxxxxxxxx
+export BILLING_WORKER_AWS_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+```
+ 
 ### Development setup:
 
 First of all you may run the whole stack locally via on docker containers or run whole tectonic k8s cluster. The latter is much more aligned with the real production configuration.


### PR DESCRIPTION
Export variables (as depicted in READ.ME) and just run:

`amm ./infra/scripts/build-run-docker.sc --stack sync --tests false --publish true --gatling true`

Here is the typical execution:

```
[BILL-SYNC] 15:17:43.577 [main] INFO  o.e.jetty.server.AbstractConnector - Started ServerConnector@75069b7f{HTTP/1.1,[http/1.1]}{0.0.0.0:8090}
[BILL-SYNC] 15:17:43.578 [main] INFO  org.eclipse.jetty.server.Server - Started @7404ms
[AUCT-SYNC] 15:17:43.646 [main] INFO  o.e.j.server.handler.ContextHandler - Started o.e.j.w.WebAppContext@3116c353{/,file:///opt/docker/src/main/webapp,AVAILABLE}
[AUCT-SYNC] 15:17:43.690 [main] INFO  o.e.jetty.server.AbstractConnector - Started ServerConnector@75069b7f{HTTP/1.1,[http/1.1]}{0.0.0.0:8080}
[AUCT-SYNC] 15:17:43.690 [main] INFO  org.eclipse.jetty.server.Server - Started @8121ms
[IDENT-SYNC] 15:17:43.950 [main] INFO  o.e.j.server.handler.ContextHandler - Started o.e.j.w.WebAppContext@624ea235{/,file:///opt/docker/src/main/webapp,AVAILABLE}
[IDENT-SYNC] 15:17:43.972 [main] INFO  o.e.jetty.server.AbstractConnector - Started ServerConnector@3aa078fd{HTTP/1.1,[http/1.1]}{0.0.0.0:8100}
[IDENT-SYNC] 15:17:43.972 [main] INFO  org.eclipse.jetty.server.Server - Started @6624ms
⢌⡱ Running docker images: Start up...                                                               
***************************************************
Apps are running on ports:
        auction-house-primary-sync:8080
        billing-service-secondary-sync:8090
        identity-service-tertiary-sync:8100
        payment-system:9000
        gatling-tests:<no port exposed>
***************************************************

[GATLING] 15:18:43.446 [GatlingSystem-akka.actor.default-dispatcher-3] INFO  akka.event.slf4j.Slf4jLogger - Slf4jLogger started
[GATLING] 15:18:44.764 [GatlingSystem-akka.actor.default-dispatcher-3] INFO  i.g.c.stats.writer.LogFileDataWriter - Initializing
[GATLING] 15:18:44.765 [GatlingSystem-akka.actor.default-dispatcher-2] INFO  i.g.c.stats.writer.ConsoleDataWriter - Initializing
[GATLING] 15:18:44.799 [GatlingSystem-akka.actor.default-dispatcher-2] INFO  i.g.c.stats.writer.ConsoleDataWriter - Initialized
[GATLING] 15:18:44.934 [GatlingSystem-akka.actor.default-dispatcher-3] INFO  i.g.c.stats.writer.LogFileDataWriter - Initialized
[GATLING] 15:18:45.338 [main] INFO  io.gatling.http.ahc.HttpEngine - Start warm up                  
[GATLING] 15:18:45.616 [main] INFO  io.gatling.http.ahc.HttpEngine - Warm up done                   
Simulation com.virtuslab.auctionHouse.perfTests.AuctionHouseSimulation started...                   
[GATLING] 15:18:46.025 [GatlingSystem-akka.actor.default-dispatcher-4] INFO  i.gatling.core.controller.Controller - InjectionStopped expectedCount=2
[IDENT-SYNC] 15:18:46.599 [qtp770911223-12] INFO  Accounts - [c587fd9a-1b4f-4aa9-b541-717754988e4d] Received account creation request for user 'qOMXrJoimPmGYou' ...
[IDENT-SYNC] 15:18:46.600 [qtp770911223-13] INFO  Accounts - [79d0e5f0-def4-4223-8007-d9b40edda2c9] Received account creation request for user 'USdqdUvOkRdshpP' ...
[IDENT-SYNC] 15:18:46.617 [qtp770911223-13] INFO  c.d.driver.core.GuavaCompatibility - Detected Guava >= 19 in the classpath, using modern compatibility layer
[IDENT-SYNC] 15:18:46.909 [qtp770911223-13] INFO  c.datastax.driver.core.ClockFactory - Using native clock to generate timestamps.
[IDENT-SYNC] 15:18:47.044 [qtp770911223-13] INFO  com.datastax.driver.core.NettyUtil - Did not find Netty's native epoll transport in the classpath, defaulting to NIO.
[IDENT-SYNC] 15:18:48.367 [qtp770911223-13] INFO  c.d.d.c.p.DCAwareRoundRobinPolicy - Using data-center name 'datacenter1' for DCAwareRoundRobinPolicy (if this is incorrect, please provide the correct datacenter name with DCAwareRoundRobinPolicy constructor)
[IDENT-SYNC] 15:18:48.369 [qtp770911223-13] INFO  com.datastax.driver.core.Cluster - New Cassandra host cassandra/172.20.0.2:9042 added
[IDENT-SYNC] 15:18:49.044 [qtp770911223-12] INFO  Accounts - [c587fd9a-1b4f-4aa9-b541-717754988e4d] Account for 'qOMXrJoimPmGYou' created.
[IDENT-SYNC] 15:18:49.118 [qtp770911223-13] INFO  Accounts - [79d0e5f0-def4-4223-8007-d9b40edda2c9] Account for 'USdqdUvOkRdshpP' created.
[IDENT-SYNC] 15:18:49.244 [qtp770911223-15] INFO  SignIn - [22461274-6652-4d85-87a2-a081f4d9022e] Received sign in request for user 'qOMXrJoimPmGYou' ...
[IDENT-SYNC] 15:18:49.244 [qtp770911223-16] INFO  SignIn - [b1d3593c-e98f-454c-b9d2-b7dd94fb9e34] Received sign in request for user 'USdqdUvOkRdshpP' ...
[IDENT-SYNC] 15:18:49.400 [qtp770911223-16] INFO  SignIn - [b1d3593c-e98f-454c-b9d2-b7dd94fb9e34] Successful sign in for user 'USdqdUvOkRdshpP', responding with access token.
[IDENT-SYNC] 15:18:49.400 [qtp770911223-15] INFO  SignIn - [22461274-6652-4d85-87a2-a081f4d9022e] Successful sign in for user 'qOMXrJoimPmGYou', responding with access token.
⢎⡰ Running docker images: Started...                                                                
================================================================================
2018-04-06 15:18:49                                           5s elapsed
---- Requests ------------------------------------------------------------------
> Global                                                   (OK=4      KO=0     )
> Account creation                                         (OK=2      KO=0     )
> sign in                                                  (OK=2      KO=0     )

---- Bid in auction ------------------------------------------------------------
[--------------------------------------------------------------------------]  0%
          waiting: 0      / active: 1      / done:0     
---- Create auction ------------------------------------------------------------
[--------------------------------------------------------------------------]  0%
          waiting: 0      / active: 1      / done:0     
================================================================================

[IDENT-SYNC] 15:18:50.180 [qtp770911223-15] INFO  Validation - [9f073ecf-5582-4503-8a3a-660883ae57ad] Received validate token request...
[IDENT-SYNC] 15:18:50.180 [qtp770911223-16] INFO  Validation - [8a4cdddb-0e0f-4dd3-ad89-a2446421d521] Received validate token request...
[IDENT-SYNC] 15:18:50.195 [qtp770911223-15] INFO  Validation - [9f073ecf-5582-4503-8a3a-660883ae57ad] Successful validation of token, responding with user name 'qOMXrJoimPmGYou'.
[IDENT-SYNC] 15:18:50.195 [qtp770911223-16] INFO  Validation - [8a4cdddb-0e0f-4dd3-ad89-a2446421d521] Successful validation of token, responding with user name 'USdqdUvOkRdshpP'.
[AUCT-SYNC] 15:18:50.300 [qtp770911223-13] INFO  AuctionHouse - [8a4cdddb-0e0f-4dd3-ad89-a2446421d521] Got create auction request for user 'USdqdUvOkRdshpP'.
[AUCT-SYNC] 15:18:50.308 [qtp770911223-15] INFO  AuctionHouse - [9f073ecf-5582-4503-8a3a-660883ae57ad] Got list auctions request for category 'pets & animals'.
[AUCT-SYNC] 15:18:50.316 [qtp770911223-15] INFO  c.v.a.sync.auctions.AuctionsService - Billing url is: http://billing-service-secondary-sync:8090/api/v1/billing
[AUCT-SYNC] 15:18:50.333 [qtp770911223-15] INFO  c.d.driver.core.GuavaCompatibility - Detected Guava >= 19 in the classpath, using modern compatibility layer
[AUCT-SYNC] 15:18:50.548 [qtp770911223-15] INFO  c.datastax.driver.core.ClockFactory - Using native clock to generate timestamps.
[AUCT-SYNC] 15:18:50.704 [qtp770911223-15] INFO  com.datastax.driver.core.NettyUtil - Did not find Netty's native epoll transport in the classpath, defaulting to NIO.
[AUCT-SYNC] 15:18:51.966 [qtp770911223-15] INFO  c.d.d.c.p.DCAwareRoundRobinPolicy - Using data-center name 'datacenter1' for DCAwareRoundRobinPolicy (if this is incorrect, please provide the correct datacenter name with DCAwareRoundRobinPolicy constructor)
[AUCT-SYNC] 15:18:51.968 [qtp770911223-15] INFO  com.datastax.driver.core.Cluster - New Cassandra host cassandra/172.20.0.2:9042 added
[AUCT-SYNC] 15:18:52.246 [qtp770911223-13] INFO  AuctionHouse - [8a4cdddb-0e0f-4dd3-ad89-a2446421d521] Created auction 'b400f133-e34c-4492-9481-7739d205fa26' for user 'USdqdUvOkRdshpP'.
[IDENT-SYNC] 15:18:52.494 [qtp770911223-19] INFO  Validation - [ebb1d3c3-50fc-4399-a26e-14c7452b4ae7] Received validate token request...
[IDENT-SYNC] 15:18:52.498 [qtp770911223-19] INFO  Validation - [ebb1d3c3-50fc-4399-a26e-14c7452b4ae7] Successful validation of token, responding with user name 'qOMXrJoimPmGYou'.
[AUCT-SYNC] 15:18:52.508 [qtp770911223-18] INFO  AuctionHouse - [ebb1d3c3-50fc-4399-a26e-14c7452b4ae7] Got fetch request for auction '870cd230-4cec-4ec5-91c1-a4f8ddc7da45'.
[AUCT-SYNC] 15:18:52.539 [qtp770911223-18] INFO  AuctionHouse - [ebb1d3c3-50fc-4399-a26e-14c7452b4ae7] Fetched auction '870cd230-4cec-4ec5-91c1-a4f8ddc7da45'.
[IDENT-SYNC] 15:18:52.595 [qtp770911223-16] INFO  Validation - [f04432be-8136-49da-8458-74749c68f48c] Received validate token request...
[IDENT-SYNC] 15:18:52.598 [qtp770911223-16] INFO  Validation - [f04432be-8136-49da-8458-74749c68f48c] Successful validation of token, responding with user name 'qOMXrJoimPmGYou'.
[AUCT-SYNC] 15:18:52.607 [qtp770911223-15] INFO  AuctionHouse - [f04432be-8136-49da-8458-74749c68f48c] Received bid in auction request for auction '870cd230-4cec-4ec5-91c1-a4f8ddc7da45'.
[AUCT-SYNC] 15:18:52.679 [qtp770911223-15] INFO  com.datastax.driver.core.utils.UUIDs - PID obtained through native call to getpid(): 0
[AUCT-SYNC] 15:18:52.687 [qtp770911223-15] INFO  AuctionHouse - [f04432be-8136-49da-8458-74749c68f48c] Added bid for auction '870cd230-4cec-4ec5-91c1-a4f8ddc7da45'.
[IDENT-SYNC] 15:18:52.702 [qtp770911223-19] INFO  Validation - [370cdce7-19a2-48eb-a467-3394b13f071b] Received validate token request...
[IDENT-SYNC] 15:18:52.708 [qtp770911223-19] INFO  Validation - [370cdce7-19a2-48eb-a467-3394b13f071b] Successful validation of token, responding with user name 'qOMXrJoimPmGYou'.
[AUCT-SYNC] 15:18:52.714 [qtp770911223-18] INFO  AuctionHouse - [370cdce7-19a2-48eb-a467-3394b13f071b] Got fetch request for auction '7ab69f97-57c3-4e98-9f8b-d36565e4e275'.
[AUCT-SYNC] 15:18:52.727 [qtp770911223-18] INFO  AuctionHouse - [370cdce7-19a2-48eb-a467-3394b13f071b] Fetched auction '7ab69f97-57c3-4e98-9f8b-d36565e4e275'.
[IDENT-SYNC] 15:18:52.776 [qtp770911223-19] INFO  Validation - [850d83b9-a79c-4afb-927c-1397c41fe5c5] Received validate token request...
[IDENT-SYNC] 15:18:52.779 [qtp770911223-19] INFO  Validation - [850d83b9-a79c-4afb-927c-1397c41fe5c5] Successful validation of token, responding with user name 'qOMXrJoimPmGYou'.
[AUCT-SYNC] 15:18:52.791 [qtp770911223-15] INFO  Finalization - [850d83b9-a79c-4afb-927c-1397c41fe5c5] Finalization triggered by 'qOMXrJoimPmGYou'.
[AUCT-SYNC] 15:18:52.793 [qtp770911223-15] INFO  c.v.a.sync.auctions.AuctionsService - Billing url is: http://billing-service-secondary-sync:8090/api/v1/billing
[AUCT-SYNC] 15:18:52.809 [qtp770911223-15] WARN  Finalization - [850d83b9-a79c-4afb-927c-1397c41fe5c5] Bidder 'qOMXrJoimPmGYou' is not auction '7ab69f97-57c3-4e98-9f8b-d36565e4e275' winner.
[GATLING] 15:18:52.814 [gatling-http-thread-1-5] WARN  i.gatling.http.ahc.ResponseProcessor - Request 'Pay for auction' failed: status.find.in(200), but actually found 400
[GATLING] 15:18:52.816 [GatlingSystem-akka.actor.default-dispatcher-2] INFO  i.gatling.core.controller.Controller - All users are stopped

================================================================================
2018-04-06 15:18:52                                           8s elapsed
---- Requests ------------------------------------------------------------------
> Global                                                   (OK=9      KO=1     )
> Account creation                                         (OK=2      KO=0     )
> sign in                                                  (OK=2      KO=0     )
> create auction                                           (OK=1      KO=0     )
> list auctions                                            (OK=1      KO=0     )
> get auction                                              (OK=1      KO=0     )
> Bid in auction                                           (OK=1      KO=0     )
> get auction with bids                                    (OK=1      KO=0     )
> Pay for auction                                          (OK=0      KO=1     )
---- Errors --------------------------------------------------------------------
> status.find.in(200), but actually found 400                         1 (100.0%)

---- Bid in auction ------------------------------------------------------------
[##########################################################################]100%
          waiting: 0      / active: 0      / done:1     
---- Create auction ------------------------------------------------------------
[##########################################################################]100%
          waiting: 0      / active: 0      / done:1     
================================================================================

[GATLING] 15:18:52.834 [GatlingSystem-akka.actor.default-dispatcher-6] INFO  i.gatling.core.controller.Controller - StatsEngineStopped
Simulation com.virtuslab.auctionHouse.perfTests.AuctionHouseSimulation completed in 6 seconds
Parsing log file(s)...es: Started...                                                                
[GATLING] 15:18:52.904 [main] INFO  i.gatling.charts.stats.LogFileReader - Collected ArrayBuffer(/opt/docker/results/auctionhousesimulation-1523027924697/simulation.log) from auctionhousesimulation-1523027924697
[GATLING] 15:18:52.915 [main] INFO  i.gatling.charts.stats.LogFileReader - First pass
[GATLING] 15:18:52.948 [main] INFO  i.gatling.charts.stats.LogFileReader - First pass done: read 16 lines
[GATLING] 15:18:52.958 [main] INFO  i.gatling.charts.stats.LogFileReader - Second pass
[GATLING] 15:18:52.998 [main] INFO  i.gatling.charts.stats.LogFileReader - Second pass: read 16 lines
Parsing log file(s) done
Generating reports...
⢌⡱ Running docker images: Started...                                                                
================================================================================
---- Global Information --------------------------------------------------------
> request count                                         10 (OK=9      KO=1     )
> min response time                                     46 (OK=46     KO=50    )
> max response time                                   3154 (OK=3154   KO=50    )
> mean response time                                  1255 (OK=1389   KO=50    )
> std deviation                                       1386 (OK=1399   KO=0     )
> response time 50th percentile                        235 (OK=242    KO=50    )
> response time 75th percentile                       2748 (OK=2755   KO=50    )
> response time 95th percentile                       3149 (OK=3150   KO=50    )
> response time 99th percentile                       3153 (OK=3153   KO=50    )
> mean requests/sec                                  1.429 (OK=1.286  KO=0.143 )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                             5 ( 50%)
> 800 ms < t < 1200 ms                                   0 (  0%)
> t > 1200 ms                                            4 ( 40%)
> failed                                                 1 ( 10%)
---- Errors --------------------------------------------------------------------
> status.find.in(200), but actually found 400                         1 (100.0%)
================================================================================

Reports generated in 0s.
Please open the following file: /opt/docker/results/auctionhousesimulation-1523027924697/index.html
Global: percentage of successful requests is greater than or equal to 100.0 : false
Result directory generated:
 > /opt/docker/results/auctionhousesimulation-1523027924697
```