### PR TITLE
gatling -  multi user mode

### DIFF
--- a/codebase/gatling-tests/src/main/resources/application.conf
+++ b/codebase/gatling-tests/src/main/resources/application.conf
@@ -13,3 +13,5 @@ reports {
 
 startDelaySeconds = 1
 startDelaySeconds = ${?GATLING_DELAY}
+
+usersNo=1

--- a/codebase/gatling-tests/src/main/scala/com/virtuslab/auctionHouse/perfTests/AccountsActions.scala
+++ b/codebase/gatling-tests/src/main/scala/com/virtuslab/auctionHouse/perfTests/AccountsActions.scala
@@ -15,17 +15,12 @@ class AccountsActions(errorHandler: ErrorHandler) extends BaseActions(errorHandl
   val scenarioErrors = new ConcurrentLinkedQueue[String]()
   def url(path: String) =  s"http://${Config.identityServiceContactPoint}/api/${Config.apiVersion}/$path"
 
-  def createAccount(username: String = randStr, password: String = randStr) = {
+  def createAccount = {
     http("Account creation")
       .post(url("accounts"))
       .header("Content-Type", "application/json")
-      .body(StringBody(s"""{"username": "${username}", "password" : "${password}"}"""))
-      .check(
-        status.is(201),
-        status.transform(_ match {
-          case 201 => Some(SessionParams.Account(username, password))
-          case _ => None
-        }).saveAs(SessionParams.account))
+      .body(StringBody("""{"username": "${username}", "password" : "${password}" }"""))
+      .check(status.is(201))
   }
 
   def signIn = {
@@ -35,7 +30,7 @@ class AccountsActions(errorHandler: ErrorHandler) extends BaseActions(errorHandl
       .body(StringBody(SessionParams.signInRequestTemplate))
       .check(
         status.in(200),
-        jsonPath("$.token").saveAs(SessionParams.token)
+        jsonPath("$.token").saveAs(SessionConstants.token)
       )
   }
 }

--- a/codebase/gatling-tests/src/main/scala/com/virtuslab/auctionHouse/perfTests/BaseActions.scala
+++ b/codebase/gatling-tests/src/main/scala/com/virtuslab/auctionHouse/perfTests/BaseActions.scala
@@ -12,19 +12,17 @@ abstract class BaseActions(errorHandler: ErrorHandler) extends RandomHelper {
 
   object SessionParams {
 
-    case class Account(username: String, password: String)
-
-    val account = "account"
-    val token = "token"
-
     val signInRequestTemplate: Expression[String] = (session: Session) => {
-      session(account).asOption[Option[Account]].flatten
-        .map(account => s"""{"username": "${account.username}", "password" : "${account.password}"}""")
-        .getOrElse(errorHandler.raiseError("Account not found in gatling session"))
+      (for {
+        username <- session(SessionConstants.username).asOption[String]
+        password <- session(SessionConstants.password).asOption[String]
+      } yield {
+        s"""{"username": "$username", "password" : "$password"}"""
+      }).getOrElse(errorHandler.raiseError("Account not found in gatling session"))
     }
 
     val authHeaderValue: Expression[String] = (session: Session) => {
-      session(token).asOption[String]
+      session(SessionConstants.token).asOption[String]
         .map(token => s"bearer $token")
         .getOrElse(errorHandler.raiseError("Token not found in gatling session"))
     }
@@ -42,4 +40,12 @@ abstract class BaseActions(errorHandler: ErrorHandler) extends RandomHelper {
         .header("Authorization", SessionParams.authHeaderValue)
     }
   }
+}
+object SessionConstants {
+
+  val username = "username"
+  val password = "password"
+  val token = "token"
+  val category = "category"
+  val createAuctionRequest = "createAuctionRequest"
 }

--- a/codebase/gatling-tests/src/main/scala/com/virtuslab/auctionHouse/perfTests/Config.scala
+++ b/codebase/gatling-tests/src/main/scala/com/virtuslab/auctionHouse/perfTests/Config.scala
@@ -14,4 +14,5 @@ object Config {
 
   lazy val auctionServiceContactPoint = s"${conf.getString("auctionService.contactPoint")}"
   lazy val identityServiceContactPoint = s"${conf.getString("identityService.contactPoint")}"
+  lazy val usersNo: Int = conf.getInt("usersNo")
 }


### PR DESCRIPTION
Making gatling works with multiple users.

Users are injected in `heavisideUsers` mode instead of `rampup` mode. I think results are more interesting.

rampup:

![rampup](https://user-images.githubusercontent.com/5765278/38429972-41381bfa-39c0-11e8-9772-9495ec40e276.png)

heaviside:

![heaviside](https://user-images.githubusercontent.com/5765278/38429986-4924f9a0-39c0-11e8-8ca8-4f6adfa5cc51.png)

heaviside `heavy` :

![heaviside_heavy](https://user-images.githubusercontent.com/5765278/38430008-578c99f8-39c0-11e8-84d1-83448f5b8f36.png)

