### PR TITLE
Fugly recursive future solution for cassandra borked Cluster instance…

### DIFF
--- a/codebase/commons/src/main/scala/com/virtuslab/cassandra/CassandraClient.scala
+++ b/codebase/commons/src/main/scala/com/virtuslab/cassandra/CassandraClient.scala
@@ -1,12 +1,19 @@
 package com.virtuslab.cassandra
 
-import com.datastax.driver.core.{Cluster, Session}
+import java.util.concurrent.Executors
+import java.util.{Timer, TimerTask}
 
-import scala.concurrent.{Await, Future}
+import com.datastax.driver.core.exceptions.{InvalidQueryException, NoHostAvailableException}
+import com.datastax.driver.core.{Cluster, ResultSet, Row, Session}
+import com.typesafe.scalalogging.Logger
+
+import scala.concurrent.{Await, ExecutionContext, Future, Promise}
+import scala.util.Try
 
 trait CassandraClient {
 
   def getSession: Session
+
   def getSessionAsync: Future[Session]
 
 }
@@ -14,14 +21,55 @@ trait CassandraClient {
 trait CassandraClientImpl extends CassandraClient {
 
   import com.virtuslab.AsyncUtils.Implicits._
+
   import scala.concurrent.duration._
+
+  private val testQuery = "SELECT * FROM system_schema.keyspaces;"
 
   def cassandraContactPoint: String
 
-  private lazy val cluster = Cluster.builder().addContactPoint(cassandraContactPoint).build()
-  private lazy val sessionFuture = cluster.connectAsync("microservices").asScala
+  protected def logger: Logger
+
+  def connectWithRetries(retriesLeft: Int): Future[Session] = {
+    import CassandraDriverHelpers._
+    val sessionFutureOrError = for {
+      session <- Future {
+        Cluster.builder()
+          .addContactPoint(cassandraContactPoint)
+          .build()
+          .connectAsync("microservices").asScala
+      }.flatten
+      _ <- session.executeAsync(testQuery).asScala
+    } yield session
+
+    sessionFutureOrError.recoverWith {
+      case invalidQuery: InvalidQueryException if retriesLeft > 0 =>
+        logger.warn(s"Keyspace `microservices` doesn't seem to exist: ($invalidQuery), retrying in 5 sec. Retries left: $retriesLeft")
+        waitFor(5000).flatMap(_ => connectWithRetries(retriesLeft - 1))
+      case noHostAvailable: NoHostAvailableException if retriesLeft > 0 =>
+        logger.warn(s"Cassandra cluster seems to be down: ($noHostAvailable), retrying in 5 sec. Retries left: $retriesLeft")
+        waitFor(5000).flatMap(_ => connectWithRetries(retriesLeft - 1))
+    }
+  }
+
+  private val sessionFuture = connectWithRetries(60) // 60 * 5000
 
   override def getSession: Session = Await.result(sessionFuture, 15.seconds)
   override def getSessionAsync: Future[Session] = sessionFuture
+
+}
+
+object CassandraDriverHelpers {
+  implicit val ec: ExecutionContext = ExecutionContext.fromExecutor(Executors.newSingleThreadExecutor())
+
+  def waitFor(delay: Long)(implicit ec: ExecutionContext): Future[Unit] = {
+    val promise = Promise[Unit]()
+    val t = new Timer()
+    val tt: TimerTask = new TimerTask {
+      override def run(): Unit = ec.execute(() => promise complete Try(()))
+    }
+    t.schedule(tt, delay)
+    promise.future
+  }
 
 }

--- a/codebase/commons/src/test/resources/schema.cql
+++ b/codebase/commons/src/test/resources/schema.cql
@@ -1,11 +1,11 @@
 -- for singular cassandra node use this:
--- CREATE  KEYSPACE microservices
+-- CREATE KEYSPACE microservices
 --   WITH REPLICATION = {
 --      'class' : 'SimpleStrategy', 'replication_factor' : 1
 --   };
 
 -- for cluster with at least 2 nodes use this:
--- CREATE  KEYSPACE microservices
+-- CREATE KEYSPACE microservices
 --   WITH REPLICATION = {
 --      'class' : 'SimpleStrategy', 'replication_factor' : 2
 --   };

--- a/codebase/identity-service-tertiary-async/src/main/scala/com/virtuslab/auctionhouse/identityasync/IdentityService.scala
+++ b/codebase/identity-service-tertiary-async/src/main/scala/com/virtuslab/auctionhouse/identityasync/IdentityService.scala
@@ -19,7 +19,7 @@ trait IdentityService {
 
   def signIn(request: SignInRequest)(implicit traceId: TraceId): Future[String]
 
-  def validateToken(token: String)(implicit traceId: TraceId): Future[Option[String]] // todo add traceId when Identity is a separate service
+  def validateToken(token: String)(implicit traceId: TraceId): Future[Option[String]]
 
   case class DuplicateUser(username: String) extends RuntimeException(username)
 

--- a/infra/scripts/kubernetes/deployments.sc
+++ b/infra/scripts/kubernetes/deployments.sc
@@ -53,7 +53,7 @@ def waitForDockerRegistry(implicit progressBar: ProgressBar): Unit = {
       %% curl(
         "-k", "-w", "%{http_code}",
         "-s", "-o", "/dev/null",
-        "https://docker-registry.local/v2/_catalog" // TODO url configurable
+        "https://docker-registry.local/v2/_catalog"
       )
     }
 

--- a/infra/scripts/test.sc
+++ b/infra/scripts/test.sc
@@ -1,4 +1,0 @@
-import $file.kubernetes.tectonic
-import tectonic._
-
-println(getNodes)


### PR DESCRIPTION
…, still sh** but at least not mutable and doesn't require synchronized {} all over